### PR TITLE
Add update page buttons and events using redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "react-redux": "^5.0.5",
+    "redux": "^3.6.0"
   },
   "devDependencies": {
     "husky": "^0.13.3",
     "lint-staged": "^3.4.2",
     "prettier": "^1.3.1",
-    "react-scripts": "1.0.1"
+    "react-scripts": "1.0.1",
+    "react-test-renderer": "^15.5.4",
+    "redux-mock-store": "^1.2.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/actions/page-actions.js
+++ b/src/actions/page-actions.js
@@ -1,0 +1,10 @@
+import { SET_PAGE } from '../constants/action-types';
+
+export const setPage = pageIndex => {
+  return {
+    type: SET_PAGE,
+    payload: {
+      pageIndex
+    }
+  };
+};

--- a/src/actions/page-actions.test.js
+++ b/src/actions/page-actions.test.js
@@ -1,0 +1,15 @@
+import { setPage } from './page-actions';
+import { SET_PAGE } from '../constants/action-types';
+
+describe('actions', () => {
+  it('should create an action to set the page', () => {
+    const pageIndex = 0;
+    const expectedAction = {
+      type: SET_PAGE,
+      payload: {
+        pageIndex
+      }
+    };
+    expect(setPage(pageIndex)).toEqual(expectedAction);
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -1,19 +1,35 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import logo from './logo.svg';
-import SlidingPage from './components/sliding-page/sliding-page.js';
-import SlidingPages from './components/sliding-pages/sliding-pages.js';
+import { setPage } from './actions/page-actions';
+import SlidingPage from './components/sliding-page/sliding-page';
+import SlidingPages from './components/sliding-pages/sliding-pages';
+import DateCalendar from './components/date-calendar/date-calendar';
 
 import './app.css';
 
-class App extends Component {
+const propTypes = {
+  currPage: PropTypes.number.isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+export class App extends Component {
+  onDateClick = newPageIndex => {
+    const { dispatch } = this.props;
+    dispatch(setPage(newPageIndex));
+  };
+
   render() {
+    const { currPage } = this.props;
     return (
       <div className="app">
         <div className="app-header">
           <img src={logo} className="app-logo" alt="logo" />
           <h2>Welcome to React</h2>
         </div>
-        <SlidingPages>
+        <DateCalendar onClick={this.onDateClick} />
+        <SlidingPages currPage={currPage}>
           <SlidingPage />
           <SlidingPage />
           <SlidingPage />
@@ -23,4 +39,12 @@ class App extends Component {
   }
 }
 
-export default App;
+App.propTypes = propTypes;
+
+const mapStateToProps = state => {
+  return {
+    currPage: state.currPage
+  };
+};
+
+export default connect(mapStateToProps)(App);

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,8 +1,42 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './app';
+import ReactShallowRenderer from 'react-test-renderer/shallow';
+import configureMockStore from 'redux-mock-store';
+import { setPage } from './actions/page-actions';
+import ConnectedApp, { App } from './app';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+describe('App', () => {
+  const mockStore = configureMockStore([]);
+  const storeStateMock = {
+    currPage: 0
+  };
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+  });
+
+  it('renders connected app without crashing', () => {
+    let store = mockStore(storeStateMock);
+    const renderer = new ReactShallowRenderer();
+    renderer.render(<ConnectedApp store={store} />);
+  });
+
+  it('renders app without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<App currPage={0} dispatch={dispatch} />, div);
+  });
+
+  it('dispatches the set page action on date click', () => {
+    const properties = {
+      currPage: 0,
+      dispatch
+    };
+    const app = new App(properties);
+
+    const pageIndex = 3;
+    app.onDateClick(pageIndex);
+    expect(dispatch.mock.calls.length).toBe(1);
+    expect(dispatch.mock.calls[0][0]).toEqual(setPage(pageIndex));
+  });
 });

--- a/src/components/date-calendar/date-calendar.js
+++ b/src/components/date-calendar/date-calendar.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  onClick: PropTypes.func.isRequired
+};
+
+class DateCalendar extends Component {
+  render() {
+    const { onClick } = this.props;
+
+    return (
+      <div className="pick-a-page">
+        <button
+          type="button"
+          className="change-page"
+          onClick={() => onClick(0)}
+        >
+          Page 1
+        </button>
+        <button
+          type="button"
+          className="change-page"
+          onClick={() => onClick(1)}
+        >
+          Page 2
+        </button>
+        <button
+          type="button"
+          className="change-page"
+          onClick={() => onClick(2)}
+        >
+          Page 3
+        </button>
+      </div>
+    );
+  }
+}
+
+DateCalendar.propTypes = propTypes;
+
+export default DateCalendar;

--- a/src/components/date-calendar/date-calendar.test.js
+++ b/src/components/date-calendar/date-calendar.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+import DateCalendar from './date-calendar.js';
+
+describe('Date Calendar', () => {
+  const onClick = jest.fn();
+
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<DateCalendar onClick={onClick} />, div);
+  });
+
+  it('calls the onClick function with the correct page on click', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<DateCalendar onClick={onClick} />, div);
+
+    const buttons = div.querySelectorAll('button');
+
+    const buttonOne = buttons[0];
+    ReactTestUtils.Simulate.click(buttonOne);
+    expect(onClick.mock.calls.length).toBe(1);
+    expect(onClick.mock.calls[0][0]).toBe(0);
+
+    const buttonThree = buttons[2];
+    ReactTestUtils.Simulate.click(buttonThree);
+    expect(onClick.mock.calls.length).toBe(2);
+    expect(onClick.mock.calls[1][0]).toBe(2);
+
+    const buttonTwo = buttons[1];
+    ReactTestUtils.Simulate.click(buttonTwo);
+    expect(onClick.mock.calls.length).toBe(3);
+    expect(onClick.mock.calls[2][0]).toBe(1);
+  });
+});

--- a/src/components/sliding-pages/sliding-pages.js
+++ b/src/components/sliding-pages/sliding-pages.js
@@ -1,25 +1,17 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { isInt } from '../../utils/number-utils/number-utils.js';
+import { isInt } from '../../utils/number-utils/number-utils';
 
 import './sliding-pages.css';
 
 const propTypes = {
+  currPage: PropTypes.number.isRequired,
   children: PropTypes.arrayOf(PropTypes.element)
 };
 
 class SlidingPages extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      currPage: 0
-    };
-  }
-
   render() {
-    const { children } = this.props;
-    const { currPage } = this.state;
+    const { currPage, children } = this.props;
     const currPosition = isInt(currPage) ? currPage * 100 * -1 : 0;
 
     return (

--- a/src/components/sliding-pages/sliding-pages.test.js
+++ b/src/components/sliding-pages/sliding-pages.test.js
@@ -2,30 +2,32 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SlidingPages from './sliding-pages.js';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<SlidingPages />, div);
-});
+describe('Sliding Pages', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<SlidingPages currPage={0} />, div);
+  });
 
-it('goes to the correct position based on states current page', () => {
-  const slidingPages = new SlidingPages({});
-  expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
+  it('goes to the correct position based on states current page', () => {
+    let slidingPages = new SlidingPages({ currPage: undefined });
+    expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
 
-  slidingPages.state = { currPage: 'yo' };
-  expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
+    slidingPages = new SlidingPages({ currPage: 'yo' });
+    expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
 
-  slidingPages.state = { currPage: null };
-  expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
+    slidingPages = new SlidingPages({ currPage: null });
+    expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
 
-  slidingPages.state = { currPage: NaN };
-  expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
+    slidingPages = new SlidingPages({ currPage: NaN });
+    expect(slidingPages.render().props.style).toEqual({ left: '0vw' });
 
-  slidingPages.state = { currPage: 2 };
-  expect(slidingPages.render().props.style).toEqual({ left: '-200vw' });
+    slidingPages = new SlidingPages({ currPage: 2 });
+    expect(slidingPages.render().props.style).toEqual({ left: '-200vw' });
 
-  slidingPages.state = { currPage: 100 };
-  expect(slidingPages.render().props.style).toEqual({ left: '-10000vw' });
+    slidingPages = new SlidingPages({ currPage: 100 });
+    expect(slidingPages.render().props.style).toEqual({ left: '-10000vw' });
 
-  slidingPages.state = { currPage: -1 };
-  expect(slidingPages.render().props.style).toEqual({ left: '100vw' });
+    slidingPages = new SlidingPages({ currPage: -1 });
+    expect(slidingPages.render().props.style).toEqual({ left: '100vw' });
+  });
 });

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -1,0 +1,1 @@
+export const SET_PAGE = 'SET_PAGE';

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 import App from './app';
+import appReducer from './reducers/app-reducer';
 import registerServiceWorker from './registerServiceWorker';
+
 import './index.css';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const store = createStore(appReducer);
+
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById('root')
+);
+
 registerServiceWorker();

--- a/src/reducers/app-reducer.js
+++ b/src/reducers/app-reducer.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import currPage from './page-reducer';
+
+const appReducer = combineReducers({
+  currPage
+});
+
+export default appReducer;

--- a/src/reducers/app-reducer.test.js
+++ b/src/reducers/app-reducer.test.js
@@ -1,0 +1,8 @@
+import reducer from './app-reducer';
+import { SET_PAGE } from '../constants/action-types';
+
+describe('app reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual({ currPage: 0 });
+  });
+});

--- a/src/reducers/page-reducer.js
+++ b/src/reducers/page-reducer.js
@@ -1,0 +1,12 @@
+import { SET_PAGE } from '../constants/action-types';
+
+const currPage = (state = 0, action) => {
+  switch (action.type) {
+    case SET_PAGE:
+      return action.payload.pageIndex;
+    default:
+      return state;
+  }
+};
+
+export default currPage;

--- a/src/reducers/page-reducer.test.js
+++ b/src/reducers/page-reducer.test.js
@@ -1,0 +1,30 @@
+import reducer from './page-reducer';
+import { SET_PAGE } from '../constants/action-types';
+
+describe('pages reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual(0);
+  });
+
+  it('should handle SET_PAGE', () => {
+    let pageIndex = 8;
+    expect(
+      reducer(0, {
+        type: SET_PAGE,
+        payload: {
+          pageIndex: 8
+        }
+      })
+    ).toEqual(pageIndex);
+
+    pageIndex = -780;
+    expect(
+      reducer(0, {
+        type: SET_PAGE,
+        payload: {
+          pageIndex: -780
+        }
+      })
+    ).toEqual(pageIndex);
+  });
+});


### PR DESCRIPTION
The date calendar component holds temporary buttons for changing the
sliding pages. The events are handled through redux actions and
reducers.

Example usage of this component:
```
<DateCalendar onClick={onClickFunction} />
```

For more on redux, please see their [website](http://redux.js.org/)

Completes work on https://www.pivotaltracker.com/story/show/145820613